### PR TITLE
Fix/runtime path current session

### DIFF
--- a/scripts/runtime/setup-common.sh
+++ b/scripts/runtime/setup-common.sh
@@ -81,7 +81,13 @@ ensure_path_updated() {
     local runtime_dir="$HOME/.awd/runtimes"
     local shell_rc=""
     
-    # Detect shell and appropriate RC file
+    # First, update the current session PATH immediately
+    if [[ ":$PATH:" != *":$runtime_dir:"* ]]; then
+        export PATH="$runtime_dir:$PATH"
+        log_info "Added $runtime_dir to current session PATH"
+    fi
+    
+    # Detect shell and appropriate RC file for persistent PATH updates
     case "$SHELL" in
         */zsh)
             shell_rc="$HOME/.zshrc"
@@ -94,20 +100,23 @@ ensure_path_updated() {
             ;;
         *)
             log_warning "Unknown shell: $SHELL. You may need to manually add $runtime_dir to your PATH"
+            log_success "Runtime binaries are available in current session"
             return
             ;;
     esac
     
-    # Check if PATH already contains the runtime directory
-    if [[ ":$PATH:" != *":$runtime_dir:"* ]]; then
+    # Check if shell RC already contains the runtime directory
+    if [[ -f "$shell_rc" ]] && grep -q "\.awd/runtimes" "$shell_rc"; then
+        log_info "PATH already configured in $shell_rc"
+    else
         log_info "Adding $runtime_dir to PATH in $shell_rc"
         echo "" >> "$shell_rc"
         echo "# Added by AWD runtime setup" >> "$shell_rc"
         echo "export PATH=\"\$HOME/.awd/runtimes:\$PATH\"" >> "$shell_rc"
-        log_success "PATH updated. Please restart your shell or run: source $shell_rc"
-    else
-        log_info "PATH already contains AWD runtime directory"
+        log_info "PATH updated in $shell_rc for future sessions"
     fi
+    
+    log_success "Runtime binaries are now available!"
 }
 
 # Download file with progress

--- a/src/awd_cli/core/script_runner.py
+++ b/src/awd_cli/core/script_runner.py
@@ -39,7 +39,7 @@ class ScriptRunner:
         command = scripts[script_name]
         
         # Auto-compile any .prompt.md files in the command
-        compiled_command = self._auto_compile_prompts(command, params)
+        compiled_command, compiled_prompt_files = self._auto_compile_prompts(command, params)
         
         # Execute the final command
         print(f"Executing: {compiled_command}")
@@ -67,7 +67,7 @@ class ScriptRunner:
         with open(config_path, 'r') as f:
             return yaml.safe_load(f)
     
-    def _auto_compile_prompts(self, command: str, params: Dict[str, str]) -> str:
+    def _auto_compile_prompts(self, command: str, params: Dict[str, str]) -> tuple[str, list[str]]:
         """Auto-compile .prompt.md files and transform runtime commands.
         
         Args:
@@ -75,15 +75,17 @@ class ScriptRunner:
             params: Parameters for compilation
             
         Returns:
-            Properly formatted command for the target runtime
+            Tuple of (compiled_command, list_of_compiled_prompt_files)
         """
         # Find all .prompt.md files in the command using regex
         prompt_files = re.findall(r'(\S+\.prompt\.md)', command)
+        compiled_prompt_files = []
         
         compiled_command = command
         for prompt_file in prompt_files:
             # Compile the prompt file with current params
             compiled_path = self.compiler.compile(prompt_file, params)
+            compiled_prompt_files.append(prompt_file)
             
             # Read the compiled content
             with open(compiled_path, 'r') as f:
@@ -94,7 +96,7 @@ class ScriptRunner:
                 compiled_command, prompt_file, compiled_content, compiled_path
             )
         
-        return compiled_command
+        return compiled_command, compiled_prompt_files
     
     def _transform_runtime_command(self, command: str, prompt_file: str, 
                                  compiled_content: str, compiled_path: str) -> str:


### PR DESCRIPTION
This pull request introduces improvements to the runtime setup script and the AWD CLI's handling of `.prompt.md` files. The changes enhance user feedback, improve clarity in the CLI, and refactor the `_auto_compile_prompts` function to return additional information about compiled files.

### Runtime Setup Improvements:
* [`scripts/runtime/setup-common.sh`](diffhunk://#diff-ed5dfbc7c00183f7ae934ef6ecdc2ebc890c368befa3900573f7c5f087eacd64L84-R90): Updated the `ensure_path_updated` function to immediately update the `PATH` for the current session and provide clearer messaging about runtime binaries' availability. Persistent `PATH` updates are now checked against the shell RC file, with more explicit logging for successful updates. [[1]](diffhunk://#diff-ed5dfbc7c00183f7ae934ef6ecdc2ebc890c368befa3900573f7c5f087eacd64L84-R90) [[2]](diffhunk://#diff-ed5dfbc7c00183f7ae934ef6ecdc2ebc890c368befa3900573f7c5f087eacd64R103-R119)

### Command Compilation Enhancements:
* [`src/awd_cli/cli.py`](diffhunk://#diff-0ab50fb811d3f6882c4377a7fb00c83715a30f81ebf6ec1240532c291ac0ad92L508-R554): Modified the `preview` function to differentiate between commands that involve `.prompt.md` file compilation and those that do not. Added user-friendly warnings and panels to clarify when no `.prompt.md` files are found or compiled.
* [`src/awd_cli/core/script_runner.py`](diffhunk://#diff-bce5245c2107b07f0f24bdfbc1054969bb5a7c13bb0a46b588536e27df0bcb0bL42-R42): Updated the `_auto_compile_prompts` method to return both the compiled command and a list of compiled `.prompt.md` files, improving visibility into the compilation process. Adjusted the `run_script` method to handle this updated return value. [[1]](diffhunk://#diff-bce5245c2107b07f0f24bdfbc1054969bb5a7c13bb0a46b588536e27df0bcb0bL42-R42) [[2]](diffhunk://#diff-bce5245c2107b07f0f24bdfbc1054969bb5a7c13bb0a46b588536e27df0bcb0bL70-R88) [[3]](diffhunk://#diff-bce5245c2107b07f0f24bdfbc1054969bb5a7c13bb0a46b588536e27df0bcb0bL97-R99)