### PR TITLE
fix: update build scripts for directory-based deployment and checksum…

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -134,7 +134,7 @@ jobs:
         with:
           name: ${{ matrix.binary_name }}
           path: |
-            ./dist/${{ matrix.binary_name }}
+            ./dist/${{ matrix.binary_name }}/
             ./dist/${{ matrix.binary_name }}.sha256
           retention-days: 30
           if-no-files-found: error
@@ -191,11 +191,11 @@ jobs:
           path: ./dist/
       
       - name: Make binary executable
-        run: chmod +x ./dist/${{ matrix.binary_name }}
+        run: chmod +x ./dist/${{ matrix.binary_name }}/awd
       
       - name: Create AWD symlink for testing
         run: |
-          ln -s "$(pwd)/dist/${{ matrix.binary_name }}" "$(pwd)/awd"
+          ln -s "$(pwd)/dist/${{ matrix.binary_name }}/awd" "$(pwd)/awd"
           echo "$(pwd)" >> $GITHUB_PATH
       
       - name: Run E2E golden scenario tests
@@ -228,17 +228,30 @@ jobs:
           path: ./dist/
           merge-multiple: true
       
+      - name: Prepare release binaries
+        run: |
+          # Create tar.gz archives from directory structure for release and Homebrew
+          cd dist
+          for binary in awd-linux-x86_64 awd-darwin-x86_64 awd-darwin-arm64; do
+            tar -czf "${binary}.tar.gz" "$binary"
+            if command -v sha256sum &> /dev/null; then
+              sha256sum "${binary}.tar.gz" > "${binary}.tar.gz.sha256"
+            elif command -v shasum &> /dev/null; then
+              shasum -a 256 "${binary}.tar.gz" > "${binary}.tar.gz.sha256"
+            fi
+          done
+      
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
           files: |
-            ./dist/awd-linux-x86_64
-            ./dist/awd-linux-x86_64.sha256
-            ./dist/awd-darwin-x86_64
-            ./dist/awd-darwin-x86_64.sha256
-            ./dist/awd-darwin-arm64
-            ./dist/awd-darwin-arm64.sha256
+            ./dist/awd-linux-x86_64.tar.gz
+            ./dist/awd-linux-x86_64.tar.gz.sha256
+            ./dist/awd-darwin-x86_64.tar.gz
+            ./dist/awd-darwin-x86_64.tar.gz.sha256
+            ./dist/awd-darwin-arm64.tar.gz
+            ./dist/awd-darwin-arm64.tar.gz.sha256
 
   # Publish to PyPI (only on tags and after successful builds)  
   publish-pypi:
@@ -294,9 +307,10 @@ jobs:
       - name: Extract SHA256 checksums
         id: checksums
         run: |
-          DARWIN_ARM64_SHA=$(cat ./dist/awd-darwin-arm64.sha256 | cut -d' ' -f1)
-          DARWIN_X86_64_SHA=$(cat ./dist/awd-darwin-x86_64.sha256 | cut -d' ' -f1)
-          LINUX_X86_64_SHA=$(cat ./dist/awd-linux-x86_64.sha256 | cut -d' ' -f1)
+          # Use the checksums from the tar.gz archives (for Homebrew compatibility)
+          DARWIN_ARM64_SHA=$(cat ./dist/awd-darwin-arm64.tar.gz.sha256 | cut -d' ' -f1)
+          DARWIN_X86_64_SHA=$(cat ./dist/awd-darwin-x86_64.tar.gz.sha256 | cut -d' ' -f1)
+          LINUX_X86_64_SHA=$(cat ./dist/awd-linux-x86_64.tar.gz.sha256 | cut -d' ' -f1)
           
           echo "darwin-arm64-sha=$DARWIN_ARM64_SHA" >> $GITHUB_OUTPUT
           echo "darwin-x86_64-sha=$DARWIN_X86_64_SHA" >> $GITHUB_OUTPUT

--- a/build/awd.spec
+++ b/build/awd.spec
@@ -137,12 +137,12 @@ a = Analysis(
 
 pyz = PYZ(a.pure, a.zipped_data, cipher=None)
 
-# Switch to --onedir for faster extraction (major performance improvement)
+# Switch to --onedir for directory-based deployment (faster startup with --onedir)
 exe = EXE(
     pyz,
     a.scripts,
-    [],  # Remove a.binaries, a.zipfiles, a.datas for --onedir mode
-    exclude_binaries=True,  # Enable --onedir mode
+    [],            # Empty for --onedir mode
+    exclude_binaries=True,  # Exclude binaries for --onedir mode
     name='awd',
     debug=False,
     bootloader_ignore_signals=False,
@@ -158,14 +158,13 @@ exe = EXE(
     entitlements_file=None,
 )
 
-# Create COLLECT for --onedir distribution
 coll = COLLECT(
     exe,
     a.binaries,
     a.zipfiles,
     a.datas,
-    strip=True,  # Strip debug symbols from all binaries
-    upx=is_upx_available(),  # Apply UPX to all files if available
+    strip=True,
+    upx=is_upx_available(),
     upx_exclude=[],
-    name='awd',
+    name='awd'
 )

--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -72,9 +72,8 @@ if [ ! -f "dist/awd/awd" ]; then
     exit 1
 fi
 
-# For onedir mode, we rename the entire directory and create a symlink for the binary
-mv dist/awd "dist/$BINARY_NAME"
-ln -sf "$BINARY_NAME/awd" "dist/awd-binary"
+# Rename the directory to have the platform-specific name
+mv "dist/awd" "dist/$BINARY_NAME"
 
 # Make binary executable
 chmod +x "dist/$BINARY_NAME/awd"
@@ -90,21 +89,16 @@ fi
 
 # Show binary info
 echo -e "${GREEN}✓ Build complete!${NC}"
-echo -e "${BLUE}Binary directory: ./dist/$BINARY_NAME/${NC}"
-echo -e "${BLUE}Executable: ./dist/$BINARY_NAME/awd${NC}"
+echo -e "${BLUE}Binary: ./dist/$BINARY_NAME/awd${NC}"
 echo -e "${BLUE}Size: $(du -h "dist/$BINARY_NAME" | tail -1 | cut -f1)${NC}"
 
-# Optional: Create checksum
+# Create checksum for the binary directory (as expected by CI workflow)
 if command -v sha256sum &> /dev/null; then
-    tar -czf "dist/$BINARY_NAME.tar.gz" -C dist "$BINARY_NAME"
-    sha256sum "dist/$BINARY_NAME.tar.gz" > "dist/$BINARY_NAME.tar.gz.sha256"
-    echo -e "${BLUE}Archive: ./dist/$BINARY_NAME.tar.gz${NC}"
-    echo -e "${BLUE}Checksum: ./dist/$BINARY_NAME.tar.gz.sha256${NC}"
+    sha256sum "dist/$BINARY_NAME/awd" > "dist/$BINARY_NAME.sha256"
+    echo -e "${BLUE}Checksum: ./dist/$BINARY_NAME.sha256${NC}"
 elif command -v shasum &> /dev/null; then
-    tar -czf "dist/$BINARY_NAME.tar.gz" -C dist "$BINARY_NAME"
-    shasum -a 256 "dist/$BINARY_NAME.tar.gz" > "dist/$BINARY_NAME.tar.gz.sha256"
-    echo -e "${BLUE}Archive: ./dist/$BINARY_NAME.tar.gz${NC}"
-    echo -e "${BLUE}Checksum: ./dist/$BINARY_NAME.tar.gz.sha256${NC}"
+    shasum -a 256 "dist/$BINARY_NAME/awd" > "dist/$BINARY_NAME.sha256"
+    echo -e "${BLUE}Checksum: ./dist/$BINARY_NAME.sha256${NC}"
 fi
 
 echo -e "${GREEN}Ready for release!${NC}"

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -87,9 +87,10 @@ detect_environment() {
     log_info "Detecting environment..."
     
     # Check if we're in CI with pre-built artifacts (binary exists in ./dist/)
-    if [[ -f "./dist/$BINARY_NAME" ]]; then
+    # The binary is located at ./dist/$BINARY_NAME/awd (directory structure)
+    if [[ -d "./dist/$BINARY_NAME" ]] && [[ -f "./dist/$BINARY_NAME/awd" ]]; then
         USE_EXISTING_BINARY=true
-        log_info "Found existing binary: ./dist/$BINARY_NAME (CI mode)"
+        log_info "Found existing binary: ./dist/$BINARY_NAME/awd (CI mode)"
     else
         USE_EXISTING_BINARY=false
         log_info "No existing binary found, will build locally"
@@ -116,23 +117,27 @@ build_binary() {
     ./scripts/build-binary.sh
     
     # Verify binary was created
-    if [[ ! -f "./dist/$BINARY_NAME" ]]; then
-        log_error "Binary not found: ./dist/$BINARY_NAME"
+    # The build script creates ./dist/$BINARY_NAME/awd (directory structure)
+    if [[ ! -f "./dist/$BINARY_NAME/awd" ]]; then
+        log_error "Binary not found: ./dist/$BINARY_NAME/awd"
         exit 1
     fi
     
-    log_success "Binary built: ./dist/$BINARY_NAME"
+    log_success "Binary built: ./dist/$BINARY_NAME/awd"
 }
 
 # Set up binary for testing (exactly like CI does)
 setup_binary_for_testing() {
     log_info "=== Setting up binary for testing (mirroring CI process) ==="
     
+    # The binary is located at ./dist/$BINARY_NAME/awd (directory structure)
+    BINARY_PATH="./dist/$BINARY_NAME/awd"
+    
     # Make binary executable (like CI does)
-    chmod +x "./dist/$BINARY_NAME"
+    chmod +x "$BINARY_PATH"
     
     # Create AWD symlink for testing (exactly like CI does)
-    ln -sf "$(pwd)/dist/$BINARY_NAME" "$(pwd)/awd"
+    ln -sf "$(pwd)/dist/$BINARY_NAME/awd" "$(pwd)/awd"
     
     # Add current directory to PATH (like CI does)
     export PATH="$(pwd):$PATH"


### PR DESCRIPTION
This pull request introduces changes to streamline the build and release process by transitioning to a directory-based binary structure (`--onedir` mode) and updating workflows, scripts, and configurations accordingly. The most important changes include modifying the CI workflows to handle the new directory structure, updating scripts to align with the new binary organization, and ensuring compatibility with Homebrew by creating `.tar.gz` archives.

### Build and Release Workflow Updates:
* Updated `.github/workflows/build-release.yml` to use directory-based binaries (`./dist/${{ matrix.binary_name }}/awd`) and generate `.tar.gz` archives with corresponding `.sha256` checksums for Homebrew compatibility. [[1]](diffhunk://#diff-4d14704b6b88fb06db888f96c03a8e9b3a5e07a4ee566d97d4111b2c05210e84L137-R137) [[2]](diffhunk://#diff-4d14704b6b88fb06db888f96c03a8e9b3a5e07a4ee566d97d4111b2c05210e84L194-R198) [[3]](diffhunk://#diff-4d14704b6b88fb06db888f96c03a8e9b3a5e07a4ee566d97d4111b2c05210e84R231-R254) [[4]](diffhunk://#diff-4d14704b6b88fb06db888f96c03a8e9b3a5e07a4ee566d97d4111b2c05210e84L297-R313)

### Build Script Changes:
* Refactored `scripts/build-binary.sh` to rename directories for platform-specific names, update checksum generation to target individual binaries, and remove `.tar.gz` creation from the script. [[1]](diffhunk://#diff-511bc950171eda9b2ed67e044c5ca7f7fd22c5545ae4912987a6896783c4bb60L75-R76) [[2]](diffhunk://#diff-511bc950171eda9b2ed67e044c5ca7f7fd22c5545ae4912987a6896783c4bb60L93-R101)

### End-to-End Testing Script Updates:
* Updated `scripts/test-e2e.sh` to reflect the new directory structure, ensuring binaries are correctly located and symlinks are created for testing. [[1]](diffhunk://#diff-e17e65b56252f685c9bd259b959d5a4ac87b4103b685e68c821560c6c84e805cL90-R93) [[2]](diffhunk://#diff-e17e65b56252f685c9bd259b959d5a4ac87b4103b685e68c821560c6c84e805cL119-R140)

### Spec File Adjustments:
* Modified `build/awd.spec` to enable `--onedir` mode for faster startup and deployment, simplifying the `exe` and `coll` configurations. [[1]](diffhunk://#diff-8dedf57fca3864c0a6574b2a3df0bc4b66d236a4e0fd2cdf1892bd51f237155fL140-R145) [[2]](diffhunk://#diff-8dedf57fca3864c0a6574b2a3df0bc4b66d236a4e0fd2cdf1892bd51f237155fL161-R169)