### PR TITLE
Fix GitHub API rate limiting in CI smoke tests

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -69,6 +69,8 @@ jobs:
         pytest tests/unit tests/test_console.py
 
     - name: Run smoke tests
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         source .venv/bin/activate
         pytest tests/integration/test_runtime_smoke.py -v

--- a/scripts/runtime/setup-codex.sh
+++ b/scripts/runtime/setup-codex.sh
@@ -80,7 +80,7 @@ setup_codex() {
             # Use authenticated request if GITHUB_TOKEN is available
             if [[ -n "${GITHUB_TOKEN:-}" ]]; then
                 log_info "Using authenticated GitHub API request"
-                latest_tag=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$latest_release_url" | grep '"tag_name":' | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/')
+                latest_tag=$(curl -s -H "Authorization: token \"$GITHUB_TOKEN\"" "$latest_release_url" | grep '"tag_name":' | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/')
             else
                 log_info "Using unauthenticated GitHub API request (60 requests/hour limit)"
                 latest_tag=$(curl -s "$latest_release_url" | grep '"tag_name":' | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/')

--- a/scripts/runtime/setup-codex.sh
+++ b/scripts/runtime/setup-codex.sh
@@ -80,7 +80,8 @@ setup_codex() {
             # Use authenticated request if GITHUB_TOKEN is available
             if [[ -n "${GITHUB_TOKEN:-}" ]]; then
                 log_info "Using authenticated GitHub API request"
-                latest_tag=$(curl -s -H "Authorization: token \"$GITHUB_TOKEN\"" "$latest_release_url" | grep '"tag_name":' | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/')
+                local auth_header="Authorization: Bearer ${GITHUB_TOKEN}"
+                latest_tag=$(curl -s -H "$auth_header" "$latest_release_url" | grep '"tag_name":' | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/')
             else
                 log_info "Using unauthenticated GitHub API request (60 requests/hour limit)"
                 latest_tag=$(curl -s "$latest_release_url" | grep '"tag_name":' | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/')

--- a/scripts/runtime/setup-codex.sh
+++ b/scripts/runtime/setup-codex.sh
@@ -77,8 +77,14 @@ setup_codex() {
         
         # Try to get the latest release tag using curl
         if command -v curl >/dev/null 2>&1; then
-            log_info "Using unauthenticated GitHub API request (60 requests/hour limit)"
-            latest_tag=$(curl -s "$latest_release_url" | grep '"tag_name":' | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/')
+            # Use authenticated request if GITHUB_TOKEN is available
+            if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+                log_info "Using authenticated GitHub API request"
+                latest_tag=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$latest_release_url" | grep '"tag_name":' | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/')
+            else
+                log_info "Using unauthenticated GitHub API request (60 requests/hour limit)"
+                latest_tag=$(curl -s "$latest_release_url" | grep '"tag_name":' | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/')
+            fi
         else
             log_error "curl is required to fetch latest release information"
             exit 1


### PR DESCRIPTION
- Add GITHUB_TOKEN to smoke test step in CI
- Update setup-codex.sh to use authenticated GitHub API requests when token is available
- Prevents rate limiting issues during CI test runs
