### PR TITLE
Auto-install GitHub MCP Server when setting up Codex CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,16 @@
 
 > [!NOTE] 
 > **📋 Prerequisites**: Get a GitHub fine-grained Personal Access Token with **read-only Models permissions** at [github.com/settings/personal-access-tokens/new](https://github.com/settings/personal-access-tokens/new)
+>
+> **Optional**: Docker installed and running (enables automatic GitHub MCP Server integration with tools like `get_me`, `list_repos`, etc.)
 
 ```bash
 # 1. Install AWD CLI (zero dependencies)
 curl -sSL https://raw.githubusercontent.com/danielmeppiel/awd-cli/main/install.sh | sh
 
-# 2. Setup AI runtime with GitHub Models (OpenAI Codex here)
-awd runtime setup codex
+# 2. Set your GitHub Personal Access token
 export GITHUB_TOKEN=your_token_here
+awd runtime setup codex
 
 # 3. Initialize your first AWD project (like npm init)
 awd init my-hello-world
@@ -39,14 +41,14 @@ awd run start --param name="Developer"
 
 AWD manages LLM runtime installation and configuration automatically:
 
-- **⚡ OpenAI Codex CLI** (recommended) - OpenAI's [`codex`](https://github.com/openai/codex) with advanced code understanding and native MCP support
+- **⚡ OpenAI Codex CLI** (recommended) - OpenAI's [`codex`](https://github.com/openai/codex) with advanced code understanding and native MCP support. Automatically configures GitHub MCP Server integration when GITHUB_TOKEN and Docker are available.
 - **🔧 LLM Library** - Simon Willison's [`llm`](https://llm.datasette.io/en/stable/index.html) with 100+ models from GitHub, OpenAI, Anthropic, local Ollama, and more
 
 ```bash
 # AWD manages runtime installation
-awd runtime setup codex        # Install Codex with GitHub Models
+awd runtime setup codex        # Install Codex with GitHub Models and GitHub MCP Server
 awd runtime setup llm          # Install LLM library  
-awd runtime list              # Show installed runtimes
+awd runtime list               # Show installed runtimes
 ```
 
 ## How It Works
@@ -246,7 +248,7 @@ cd awd-cli && pip install -e .
 
 ```bash
 # Quick start commands
-awd runtime setup codex                           # Install Codex runtime
+awd runtime setup codex                           # Install Codex with automatic GitHub MCP integration
 awd init my-project                               # Initialize new AWD project
 awd install                                       # Install dependencies
 awd run start --param key=value                   # Run start script

--- a/scripts/runtime/setup-codex.sh
+++ b/scripts/runtime/setup-codex.sh
@@ -256,7 +256,7 @@ EOF
             echo "   - Your AWD scripts can now use GitHub tools like 'get_me', 'list_repos', etc."
             echo "   - Docker is available and MCP server will work automatically"
             echo "   - GitHub Models provides free access to OpenAI models with your GitHub token"
-        elif [[ -n "${GITHUB_TOKEN:-}" ]] && ! check_docker_available; then
+        elif [[ -n "${GITHUB_TOKEN:-}" ]] && [[ "$docker_available" == "false" ]]; then
             echo "1. Install and start Docker to enable GitHub tools in AWD scripts"
             echo "2. Re-run this script to enable MCP integration"
             echo "3. Then run: awd run start --param name=YourName"

--- a/scripts/runtime/setup-codex.sh
+++ b/scripts/runtime/setup-codex.sh
@@ -243,7 +243,12 @@ EOF
     log_info "Next steps:"
     if [[ "$VANILLA_MODE" == "false" ]]; then
         # Show MCP integration status and appropriate next steps
-        if [[ -n "${GITHUB_TOKEN:-}" ]] && check_docker_available; then
+        local docker_available=false
+        if check_docker_available; then
+            docker_available=true
+        fi
+        
+        if [[ -n "${GITHUB_TOKEN:-}" ]] && [[ "$docker_available" == "true" ]]; then
             echo "🚀 Ready to use AWD with GitHub integration!"
             echo "   - Run: awd run start --param name=YourName"
             echo ""


### PR DESCRIPTION
### Documentation Updates
* Updated `README.md` to include Docker as an optional prerequisite and clarified that GitHub MCP Server integration is automatically configured when `GITHUB_TOKEN` and Docker are available. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R18-R27) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L42-R49) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L249-R251)

### Script Enhancements
* Modified `scripts/runtime/setup-codex.sh` to check for Docker availability and configure GitHub MCP Server integration if both Docker and `GITHUB_TOKEN` are present. Added fallback configurations for cases where Docker or `GITHUB_TOKEN` is missing. [[1]](diffhunk://#diff-76be0897969411403b877e7f5a9d0ae18af227750474717919da2b816ddbc423R4-R26) [[2]](diffhunk://#diff-76be0897969411403b877e7f5a9d0ae18af227750474717919da2b816ddbc423L146-R210) [[3]](diffhunk://#diff-76be0897969411403b877e7f5a9d0ae18af227750474717919da2b816ddbc423R221)
* Enhanced user feedback in `setup-codex.sh` to provide clear next steps based on the availability of Docker and `GITHUB_TOKEN`.