### PR TITLE
Standardize Python version to 3.12 for Ubuntu 24.04 LTS oob compatibility

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 
 **Environment (please complete the following information):**
  - OS: [e.g. macOS, Linux, Windows]
- - Python Version: [e.g. 3.13.0]
+ - Python Version: [e.g. 3.12.0]
  - AWD-CLI Version: [e.g. 0.1.0]
  - VSCode Version (if relevant): [e.g. 1.80.0]
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,7 +1,7 @@
 name: CI/CD Pipeline
 
 env:
-  PYTHON_VERSION: '3.13'  # Standardize on 3.13 for compatibility
+  PYTHON_VERSION: '3.12'  # Standardize on 3.12 for Ubuntu 24.04 LTS compatibility
 
 on:
   push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.14] - 2025-01-19
+
+### Changed
+- **Python Version Standardization** - Standardized build environment to Python 3.12 for better Ubuntu 24.04 LTS compatibility
+- **Build System Optimization** - Updated CI/CD pipeline to use Python 3.12 for binary builds, resolving shared library issues on Ubuntu systems
+
+### Technical
+- Updated GitHub Actions workflow to use Python 3.12 consistently
+- Updated development tools (black, mypy) to target Python 3.12
+- Improved binary compatibility with Ubuntu 24.04 LTS default Python version
+
 ## [0.0.13] - 2025-01-19
 
 ### Added

--- a/docs/integration-testing.md
+++ b/docs/integration-testing.md
@@ -137,7 +137,7 @@ All integration tests run on:
 - **macOS Intel**: macos-13 (x86_64) 
 - **macOS Apple Silicon**: macos-14 (arm64)
 
-**Python Version**: 3.13 (standardized across all environments)
+**Python Version**: 3.12 (standardized across all environments)
 **Package Manager**: uv (for fast dependency management and virtual environments)
 
 ## What the Tests Verify

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,11 @@ authors = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9", 
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
@@ -52,13 +57,13 @@ include = ["awd_cli*"]
 
 [tool.black]
 line-length = 88
-target-version = ["py313"]
+target-version = ["py312"]
 
 [tool.isort]
 profile = "black"
 line_length = 88
 
 [tool.mypy]
-python_version = "3.13"
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,14 +7,13 @@ name = "awd-cli"
 version = "0.0.13"
 description = "MCP configuration tool"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {file = "LICENSE"}
 authors = [
     {name = "Daniel Meppiel", email = "user@example.com"}
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9", 
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "awd-cli"
-version = "0.0.13"
+version = "0.0.14"
 description = "MCP configuration tool"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9", 
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -209,7 +209,7 @@ install_test_dependencies() {
     # Check if uv is available, otherwise use pip
     if command -v uv >/dev/null 2>&1; then
         log_info "Using uv for dependency installation..."
-        uv venv --python 3.13 || uv venv  # Try 3.13 first, fallback to default
+        uv venv --python 3.12 || uv venv  # Try 3.12 first, fallback to default
         source .venv/bin/activate
         uv pip install -e ".[dev]"
     else


### PR DESCRIPTION
### Python version standardization:

* [`.github/workflows/build-release.yml`](diffhunk://#diff-4d14704b6b88fb06db888f96c03a8e9b3a5e07a4ee566d97d4111b2c05210e84L4-R4): Changed the `PYTHON_VERSION` environment variable from `3.13` to `3.12` to ensure compatibility with Ubuntu 24.04 LTS.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L55-R67): Updated `target-version` in the Black configuration and `python_version` in the MyPy configuration from `3.13` to `3.12`.

### Expanded Python version support:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R17-R21): Added Python versions `3.9`, `3.10`, `3.11`, and `3.12` to the `classifiers` section to reflect broader compatibility.

Closes #19 